### PR TITLE
fix job status and theme settings from source to target site

### DIFF
--- a/src/Job/DuplicateSite.php
+++ b/src/Job/DuplicateSite.php
@@ -173,6 +173,7 @@ class DuplicateSite extends AbstractJob
             $this->copyCollecting($source, $target);
         }
 
+        $this->indexPages($target);
         // Assign resources and reindex pages.
         $services->get(\Omeka\Job\Dispatcher::class)->dispatch(
             \Omeka\Job\UpdateSiteItems::class,
@@ -183,7 +184,6 @@ class DuplicateSite extends AbstractJob
             $services->get(\Omeka\Job\DispatchStrategy\Synchronous::class)
         );
 
-        $this->indexPages($target);
 
         if ($this->job->getStatus() === \Omeka\Entity\Job::STATUS_ERROR) {
             $this->logger->warn(
@@ -480,10 +480,11 @@ SQL;
         // The settings may be already copied with other settings.
         $siteSettings = $this->getServiceLocator()->get('Omeka\Settings\Site');
         $siteSettings->setTargetId($source->getId());
-        $themeSettings = $siteSettings->get('theme_settings_' . $theme) ?: '{}';
+        $themeSettings = $siteSettings->get('theme_settings_' . $theme);
         $siteSettings->setTargetId($target->getId());
-        $siteSettings->set('theme_settings_' . $theme, $themeSettings);
-
+        if ($themeSettings) {
+            $siteSettings->set('theme_settings_' . $theme, $themeSettings);
+        }
         $this->entityManager->flush();
     }
 


### PR DESCRIPTION
Dans le Job que lance le module, même si dans les faits l'action se passe visuellement sans encombres, le statut tombe en erreur. Doctrine nous lance alors un log nous indiquant qu'une entité inconnue à été trouvée.. 
Il se trouve que la fonction "indexPages" en fin de Job est appelé après l'appel de la class "Job\Dispatcher" qui "clear" l'entityManager et qui produit donc l'erreur citée précédemment.
En déplaçant l'appel de la fonction "indexPages" quelques lignes avant, l'erreur n'existe plus.

Nous en avons profité également pour corriger le fait que lors d'une copie si l'on cherche à avoir accès directement au site "copie" un message d'erreur intervient concernant les réglages du thème qui ne sont pas accessibles. Ajoutant une condition qui vérifie si les réglages du thème existe, nous évitons ce comportement.