### PR TITLE
Fixed a bug about missing search query params

### DIFF
--- a/src/View/Helper/LanguageList.php
+++ b/src/View/Helper/LanguageList.php
@@ -220,7 +220,7 @@ class LanguageList extends AbstractHelper
                 'site' => $siteSlug,
                 'locale' => $localeId,
                 'locale_label' => $this->localeLabels[$localeId],
-                'url' => $urlHelper(null, ['site-slug' => $siteSlug], true),
+                'url' => $urlHelper(null, ['site-slug' => $siteSlug], ['query' => $params->fromQuery()], true),
             ];
         }
 


### PR DESCRIPTION
Currently, when the language switcher links to pages, it doesn't maintain any existing URL query parameters. For example, if you were to make a search (not using Advanced Search module) and then change languages on the results page, the search will be cleared. Similarly, if you set a sort on the browse page and then change languages, the sort will be reset.

I went ahead and patched this bug. Thank you in advance for your consideration!