### PR TITLE
fix SQL statement

### DIFF
--- a/src/Service/ViewHelper/LanguageListFactory.php
+++ b/src/Service/ViewHelper/LanguageListFactory.php
@@ -33,13 +33,15 @@ SELECT site.slug AS site_slug, REPLACE(site_setting.value, '"', "") AS localeId
 FROM site_setting
 JOIN site ON site.id = site_setting.site_id
 WHERE site_setting.id = :setting_id
-ORDER BY site.id ASC
 SQL;
         $bind = ['setting_id' => 'locale'];
+
         if ($isPublic) {
             $sql .= ' AND site.is_public = :is_public';
             $bind['is_public'] = 1;
         }
+
+        $sql .= ' ORDER BY site.id ASC';
 
         /** @var \Doctrine\DBAL\Connection $connection */
         $connection = $services->get('Omeka\Connection');


### PR DESCRIPTION
- Fixes SQL statement to 
  - prevent an Omeka-S error for anonymous (not logged in users)
  - correctly add the `is_public` portion to the `WHERE` clause

As it was, previous to the addition of `ASC` to the `ORDER BY` clause, the `is_public` piece seems to have done nothing. I believe it was intended to be in the `WHERE` clause.